### PR TITLE
Improve annotations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1453,6 +1453,26 @@ files = [
 ]
 
 [[package]]
+name = "typst"
+version = "0.8.0"
+description = "Python binding to typst"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "typst-0.8.0-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:8b50c994e7b819c39f8adc3d82b593d1780ea76604b8f30043375be5efe393aa"},
+    {file = "typst-0.8.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:b023a72ecd7be2dc73c636b55a323dcc8bd922c4983d8eec5202248ffcdef828"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3ffff086fe48ebe93daacdcbcbb4d3f185388866e77e07570114884c237c8f44"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:284b205fa6ae160aa85e20737d87c4b1b6d0ebfdeabb6895a3bb333d1c53ee18"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71c97d0ad34c6bfe2ac5c1b5c5a81a905f68f74f8df067a5c75effa13556614d"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91033fc54af5160891b15f8e73550bff984fdee539e335c55d6d69275ff5c64d"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e04d751ee8fa941444d225ea8e35eb3f5073aedbfe3dd4a7cf1e572c5b2f8a3"},
+    {file = "typst-0.8.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da71d9011fc5e70b9180b162e72db85da28e0d47e13ae76fa4fc304e14d0ea8a"},
+    {file = "typst-0.8.0-cp37-abi3-win32.whl", hash = "sha256:a820a7b672cbfd68cd2dbedea4e99c2b5b791b0e659dd0f438c9684c5ca26e81"},
+    {file = "typst-0.8.0-cp37-abi3-win_amd64.whl", hash = "sha256:429d2a115180dbbe80ebeafa7569922f6144e6c8b58598dd3fb642f6e8ad7423"},
+    {file = "typst-0.8.0.tar.gz", hash = "sha256:c46f0581cd312905618ae3573737e025a5c521ca810c83c9ebb2ba7994f04ad3"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.0.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1559,4 +1579,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "522e42f66d626f5ad0fd7a57ed0b5faf257f12a9b8ff32a80db109d6b960f74e"
+content-hash = "8ac59f4aa2c189156d5728787305aa2c81ae9d41aeabb07dca97b614c6741d00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ annotate = "superlesson:annotate_step"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+typst = "^0.8.0"
 
 [tool.poetry.group.transcribe.dependencies]
 faster-whisper = "^0.9.0"


### PR DESCRIPTION
## Description

This PR introduces a typst backend for generating annotations. We create a temporary PDF file using typst then use pypdf to interpolate that with the pre-existing lecture notes.

This PR closes #27 

Note that `poetry.lock` has been auto-updated when adding the new dependencies.

## Pull Request Requirements
- [ ] I have linked my pull request to the corresponding issue (if it exists).
- [ ] I have updated the documentation (if necessary).
- [ ] I have added tests that prove my fix is effective or that my feature works (if necessary).
