### PR TITLE
Fix txt files being used as lecture notes

### DIFF
--- a/superlesson/storage/lesson.py
+++ b/superlesson/storage/lesson.py
@@ -121,7 +121,14 @@ class LessonFiles:
                 [self._annotate_with, FileType.notes, FileType.video])
             if not files:
                 raise ValueError(f"Notes file not found on {self.lesson_root}")
-            self._lecture_notes = files[0]
+            for file in files:
+                if file.file_type == FileType.video:
+                    raise NotImplementedError("Annotating from video is not implemented yet")
+                if file.name.endswith(".pdf"):
+                    self._lecture_notes = file
+                    break
+            if self._lecture_notes is None:
+                raise ValueError(f"Notes file not found on {self.lesson_root}")
 
         logging.debug(f"Lecture notes: {self._lecture_notes}")
         return self._lecture_notes

--- a/superlesson/storage/lesson.py
+++ b/superlesson/storage/lesson.py
@@ -103,12 +103,12 @@ class LessonFiles:
     def transcription_source(self) -> LessonFile:
         """The file to be used for transcription."""
         if self._transcription_source is None:
-            transcription_file = self._find_lesson_file(
+            files = self._find_lesson_files(
                 [self._transcribe_with, FileType.video, FileType.audio])
-            if transcription_file is None:
+            if not files:
                 raise ValueError(
                     f"Transcription file not found on {self.lesson_root}")
-            self._transcription_source = transcription_file
+            self._transcription_source = files[0]
 
         logging.debug(f"Transcription source: {self._transcription_source}")
         return self._transcription_source
@@ -117,24 +117,24 @@ class LessonFiles:
     def lecture_notes(self) -> LessonFile:
         """The file to be used for annotation."""
         if self._lecture_notes is None:
-            notes_file = self._find_lesson_file(
+            files = self._find_lesson_files(
                 [self._annotate_with, FileType.notes, FileType.video])
-            if notes_file is None:
+            if not files:
                 raise ValueError(f"Notes file not found on {self.lesson_root}")
-            self._lecture_notes = notes_file
+            self._lecture_notes = files[0]
 
         logging.debug(f"Lecture notes: {self._lecture_notes}")
         return self._lecture_notes
 
-    def _find_lesson_file(self, accepted_types: List[Optional[FileType]]) -> Optional[LessonFile]:
+    def _find_lesson_files(self, accepted_types: List[Optional[FileType]]) -> List[LessonFile]:
         for file_type in accepted_types:
             if file_type is None:
                 continue
             files = self._get_files(file_type)
             if len(files) > 0:
-                return files[0]
+                return files
 
-        return None
+        return []
 
     def _get_files(self, file_type: FileType) -> List[LessonFile]:
         """Get all files of a given type."""

--- a/superlesson/storage/lesson.py
+++ b/superlesson/storage/lesson.py
@@ -6,6 +6,8 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Optional
 
+from .store import Store
+
 
 class FileType(Enum):
     video = "video"
@@ -88,10 +90,14 @@ class LessonFiles:
             return self._files
 
         logging.info("Searching for files...")
+        ignored = list(Store.txt_files())
+        ignored.append("transcription.pdf")
         for file in self.lesson_root.iterdir():
+            if file.name in ignored:
+                continue
             try:
-                logging.debug(f"Found file: {file}")
                 self._files.append(LessonFile(file.name, self.lesson_root))
+                logging.debug(f"Found file: {file}")
             except ValueError:
                 pass
 

--- a/superlesson/storage/store.py
+++ b/superlesson/storage/store.py
@@ -40,6 +40,10 @@ class Store:
         self._storage_root = lesson_root / ".data"
         self._run_all = run_all
 
+    @classmethod
+    def txt_files(cls) -> List[str]:
+        return [f"{file.name}.txt" for file in cls._storage_map.values()]
+
     def in_storage(self, step: Step) -> bool:
         return self._storage_map.get(step) is not None
 


### PR DESCRIPTION
- storage: return all files on find_lesson_files
- storage: raise when no notes are found
- storage: ignore generated files

## Description

Closes: #72

## Pull Request Requirements
- [x] I have linked my pull request to the corresponding issue (if it exists).
