### PR TITLE
lesson: fix ignored pdf file

### DIFF
--- a/superlesson/storage/lesson.py
+++ b/superlesson/storage/lesson.py
@@ -91,7 +91,7 @@ class LessonFiles:
 
         logging.info("Searching for files...")
         ignored = list(Store.txt_files())
-        ignored.append("transcription.pdf")
+        ignored.append("annotations.pdf")
         for file in self.lesson_root.iterdir():
             if file.name in ignored:
                 continue


### PR DESCRIPTION
As we changed the name for the final annotated file, we have to update
it as well in the list of ignored files.

Fixes: 7b8bc290 ("storage: ignore generated files")
