### PR TITLE
Always output txt on debug

### DIFF
--- a/superlesson/cli.py
+++ b/superlesson/cli.py
@@ -121,7 +121,10 @@ def parse_args() -> Namespace:
         "--verbose", "-v", action="store_true", help="Increase output verbosity"
     )
     mut_group.add_argument(
-        "--debug", "-d", action="store_true", help="Print debug information"
+        "--debug",
+        "-d",
+        action="store_true",
+        help="Print debug information and save step outputs as txt",
     )
     return parser.parse_args()
 
@@ -139,7 +142,7 @@ def single_step_setup(_class: Any) -> tuple[Namespace, Any]:
 
     lesson_files = LessonFiles(args.lesson, args.transcribe_with, args.annotate_with)
 
-    slides = Slides(lesson_files.lesson_root)
+    slides = Slides(lesson_files.lesson_root, args.debug)
     if _class is Annotate:
         instance = _class(slides, lesson_files.lecture_notes)
     else:
@@ -203,7 +206,7 @@ def check_differences(lesson: str, prev: Step, next: Step):
 
 
 def tmarks_step():
-    _, transitions = single_step_setup(Transitions)
+    args, transitions = single_step_setup(Transitions)
     transitions.insert_tmarks()
 
 

--- a/superlesson/steps/step.py
+++ b/superlesson/steps/step.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from enum import Enum
-from typing import Callable, Iterable, Optional
+from typing import Callable, Optional
 
 
 logger = logging.getLogger("superlesson")
@@ -22,13 +23,12 @@ class Step(Enum):
         return list([s for s in Step])
 
     @classmethod
-    def get_last(cls, step: Step) -> Iterable[Step]:
+    def get_last(cls, step: Step) -> Sequence[Step]:
         if step is cls.transcribe:
-            return
+            return []
         steps = cls.to_list()
         index = steps.index(step) - 1
-        for s in steps[index::-1]:
-            yield s
+        return steps[index::-1]
 
     def __lt__(self, other: Step) -> bool:
         steps = self.to_list()

--- a/superlesson/storage/slide.py
+++ b/superlesson/storage/slide.py
@@ -153,7 +153,12 @@ class Slides(UserList):
         assert obj is not None, "Slides object should be populated"
         data: list[Slide] = []
         for i in range(len(obj)):
-            data.append(self._load_slide(obj[i]))
+            slide = self._load_slide(obj[i])
+            # HACK: loading from transcribe will show each word as a separate slide
+            # so let's just skip those
+            if depends_on is not Step.transcribe:
+                logger.debug("Loaded slide: %s", repr(slide))
+            data.append(slide)
         self.data = data
         self._last_state = loaded
         return loaded

--- a/superlesson/storage/slide.py
+++ b/superlesson/storage/slide.py
@@ -62,11 +62,12 @@ class Slide:
 
 
 class Slides(UserList):
-    def __init__(self, lesson_root: Path):
+    def __init__(self, lesson_root: Path, always_export_txt: bool = False):
         super().__init__()
         self.lesson_root = lesson_root
         self._store = Store(lesson_root)
         self._last_state = None
+        self._always_export_txt = always_export_txt
 
     @staticmethod
     def _load_slide(slide_obj: dict) -> Slide:
@@ -172,6 +173,9 @@ class Slides(UserList):
         self._last_state = Loaded.in_memory
         if self._store.in_storage(step):
             self._store.save_json(step, [slide.to_dict() for slide in self.data])
-            self._store.save_txt(
-                step, "\n".join([str(slide) + "\n" for slide in self.data])
-            )
+            if step is Step.transcribe:
+                return
+            if self._always_export_txt or step is Step.improve_punctuation:
+                self._store.save_txt(
+                    step, "\n".join([str(slide) + "\n" for slide in self.data])
+                )

--- a/superlesson/storage/slide.py
+++ b/superlesson/storage/slide.py
@@ -127,8 +127,8 @@ class Slides(UserList):
             )
         )
 
-        transcription = "\n".join(
-            [slide.transcription for slide in self.data[first : last + 1]]
+        transcription = " ".join(
+            [slide.transcription.strip() for slide in self.data[first : last + 1]]
         )
         assert end is not None
         if first > 0:

--- a/superlesson/storage/store.py
+++ b/superlesson/storage/store.py
@@ -62,7 +62,14 @@ class Store:
 
     def _parse_txt(self, txt_path: Path) -> list[str]:
         with open(str(txt_path), "r") as f:
-            transcriptions = re.split("====== SLIDE .* ======", f.read())[1:]
+            transcriptions = re.split(r"====== SLIDE .* ======", f.read())[1:]
+
+        for i, text in enumerate(transcriptions):
+            text = text.strip()
+            text = re.sub(r"\n\n", "<br>", text)
+            text = re.sub(r"\s+", " ", text)
+            text = re.sub(r"<br>", "\n\n", text)
+            transcriptions[i] = text
 
         return transcriptions
 
@@ -83,9 +90,13 @@ class Store:
             logger.info(f"Loading {step.value} from txt file")
             transcriptions = self._parse_txt(txt_path)
 
-            if transcriptions:
+            if transcriptions and len(transcriptions) == len(data):
                 for i in range(len(data)):
                     data[i]["transcription"] = transcriptions[i]
+            else:
+                logger.warning(
+                    f"Couldn't load from file {txt_path}, make sure it's properly formatted"
+                )
 
         return data
 


### PR DESCRIPTION
If the user decides to use debug mode, they should be able to have a clean output of what the step looks like.

This also fixes some whitespace issues when importing or exporting.