### PR TITLE
Make GPT completion calls async

### DIFF
--- a/superlesson/steps/transcribe.py
+++ b/superlesson/steps/transcribe.py
@@ -305,7 +305,7 @@ class Transcribe:
         """
 
         margin = 20  # to avoid errors
-        max_input_tokens = (4096 - self._count_tokens(context)) // 2 - margin
+        max_input_tokens = (2**14 - self._count_tokens(context)) // 2 - margin
         logger.debug(f"Max input tokens: {max_input_tokens}")
 
         logger.debug("Splitting into prompts")
@@ -454,7 +454,7 @@ class Transcribe:
         logger.debug("Completing prompt: %s", prompt)
         try:
             completion = await client.chat.completions.create(
-                model="gpt-3.5-turbo",
+                model="gpt-3.5-turbo-1106",
                 # model="gpt-4",
                 messages=messages,
                 n=1,

--- a/superlesson/storage/store.py
+++ b/superlesson/storage/store.py
@@ -28,13 +28,15 @@ class Store:
             return self._storage_root / f"{filename}.json"
         return self._lesson_root / f"{filename}.txt"
 
-    def _parse_txt(self, txt_path: Path) -> list[str]:
+    @staticmethod
+    def _parse_txt(txt_path: Path) -> list[str]:
         return [
             format_transcription(text)
             for text in re.split(r"====== SLIDE .* ======", txt_path.read_text())[1:]
         ]
 
-    def _parse_json(self, json_path: Path) -> list[dict[str, Any]]:
+    @staticmethod
+    def _parse_json(json_path: Path) -> list[dict[str, Any]]:
         json_data = json_path.read_text()
         data = json_lib.loads(json_data)
 
@@ -70,7 +72,8 @@ class Store:
 
         return data
 
-    def temp_save(self, txt_data: Any) -> Path:
+    @staticmethod
+    def temp_save(txt_data: Any) -> Path:
         import tempfile
 
         with tempfile.NamedTemporaryFile(

--- a/superlesson/storage/utils.py
+++ b/superlesson/storage/utils.py
@@ -2,26 +2,30 @@ import logging
 from datetime import timedelta
 from pathlib import Path
 from textwrap import fill
+import re
 
 logger = logging.getLogger("superlesson")
 
 
 def format_transcription(text: str) -> str:
     lines = text.splitlines()
-    formatted = []
+    paragraphs = []
+    current_para = []
     for line in lines:
         if line == "":
-            if len(formatted) and formatted[-1] != "\n\n":
-                formatted.append("\n\n")
+            if current_para:
+                paragraphs.append(current_para)
+                current_para = []
         else:
-            formatted.append(fill(line, width=120, tabsize=4))
-    if not len(formatted):
-        return ""
+            line = re.sub(r"\s+", " ", line)
+            current_para.append(line)
 
-    if formatted[-1] == "\n\n":
-        return "".join(formatted[:-1])
+    if current_para:
+        paragraphs.append(current_para)
 
-    return "".join(formatted)
+    return "\n\n".join(
+        [fill(" ".join(para), width=120, tabsize=4) for para in paragraphs]
+    )
 
 
 def seconds_to_timestamp(s: float) -> str:


### PR DESCRIPTION
- transcribe: create _split_periods
- transcribe: refactor _split_text and rename
- improve: stop retrying GPT calls
- improve: track slide numbers when splitting
- improve: separate GPT API calls from logic
- improve: make GPT calls async
- improve: use GPT 16k
- improve: add wdiff for failed GPT prompts

## Description

I refactored the helper functions so that they'd deal nicely with lists, then I separated the
request part from our text manipulation logic, so that we could perform all requests at once.

Finally, some other improvements like using the 16k model and using wdiff for debugging completions.

Related to: #87
